### PR TITLE
Responsive contactform

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -66,6 +66,10 @@ h1, h2, h3, h4, h5, h6 {
   max-width: 360px;
 }
 
+.new_email_message {
+  padding-bottom: 100px;
+}
+
 .form-group img {
   max-width: 100%;
 }

--- a/app/views/email_messages/new.html.erb
+++ b/app/views/email_messages/new.html.erb
@@ -1,5 +1,5 @@
-<div class="container pb-md-5">
-  <div class="row mt-md-5 mb-md-4">
+<div class="container pb-5">
+  <div class="row mt-5 mb-4">
     <div class="col-md-8">
       <h1>Have an idea? Have a thought?</h1>
 
@@ -14,28 +14,28 @@
       <%= display_form_errors_for @message %>
 
         <div class="form-row">
-          <div class="form-group col">
+          <div class="form-group col-md-6">
             <%= f.label :name, "Your name" %>
             <%= f.text_field :name, class: 'form-control', autofocus: true, placeholder: 'Enter your full name' %>
           </div>
-          <div class="form-group col">
+          <div class="form-group col-md-6">
             <%= f.label :company, "Company name" %><sup class="text-muted ml-md-1">(optional)</sup>
             <%= f.text_field :company, class: 'form-control', placeholder: 'Enter the name of the company or organization' %>
           </div>
         </div>
 
         <div class="form-row">
-          <div class="form-group col">
+          <div class="form-group col-md-6">
             <%= f.label :email, "Email" %>
             <%= f.email_field :email, class: 'form-control', placeholder: 'Enter your email address' %>
           </div>
-          <div class="form-group col">
+          <div class="form-group col-md-6">
             <%= f.label :phone, "Contact number" %>
             <%= f.phone_field :phone, class: 'form-control', placeholder: 'Enter your contact number' %>
           </div>
         </div>
 
-        <div class="form-group mb-md-4">
+        <div class="form-group mb-4">
           <p>Preferred contact method</p>
           <div class="form-check form-check-inline">
             <%= f.radio_button :preferred_method, 'email', class: 'form-check-input', checked: true %>
@@ -47,17 +47,17 @@
           </div>
         </div>
 
-        <div class="form-group mb-md-4">
+        <div class="form-group mb-4">
           <%= f.label :reason, "Reason for contacting me" %>
           <%= f.select :reason, EmailMessage::REASONS.map { |index, value| [value, index] }, {include_blank: false}, class: 'form-control custom-select' %>
         </div>
 
-        <div class="form-group mb-md-4">
+        <div class="form-group mb-4">
           <%= f.label :brief_msg, "Additional information" %>
           <%= f.text_area :brief_msg, class: 'form-control', placeholder: 'Provide any details here' %>
         </div>
 
-        <div class="form-group mb-md-5">
+        <div class="form-group mb-5">
           <button type="submit" class="btn btn-primary shadow px-md-4 mr-md-2"><%= icon('fas', 'share', 'Send') %></button>
           <%= link_to "Return home", root_path, class: 'btn btn-light' %>
         </div>


### PR DESCRIPTION
Addressing issue #5 by changing col-md to col-lg so that smaller devices display fields at full width. Addressing issue #6 by adding 100px padding to the bottom of the form to account for the bottom toolbar on mobile devices.